### PR TITLE
Fix Direflow overwrites already set element properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -54,6 +54,12 @@ class WebComponentFactory {
       constructor() {
         super();
         this.setComponentProperties();
+
+        for (const key in this.properties) {
+          if ((this as any)[key] != null) {
+            this.properties[key] = (this as any)[key];
+          }
+        }
       }
 
       public static get observedAttributes(): string[] {
@@ -116,7 +122,9 @@ class WebComponentFactory {
 
       private preparePropertiesAndAttributes(): void {
         Object.keys(factory.componentProperties).forEach((key: string) => {
-          factory.componentProperties[key] = this.getAttribute(key) || (factory.componentProperties as any)[key];
+          factory.componentProperties[key] = this.getAttribute(key)
+            || ((this as any)[key] != null && (this as any)[key])
+            || (factory.componentProperties as any)[key];
         });
       }
 

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
-    "direflow-component": "3.0.2"
+    "direflow-component": "3.0.3"
   },
   "devDependencies": {
     "jest-environment-jsdom-fourteen": "0.1.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "direflow-component": "3.0.2",
+    "direflow-component": "3.0.3",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2"


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Direflow correctly doesn't overwrite existing attributes with default config values,
but it does overwrite existing properties on the element.
The problem is if you set the properties on the web component element too fast, Direflow will not accept those properties at the moment.

**How did you verify that your changes work as expected? Please describe**  
I encountered the issue when trying to use the web component with angular.
I forked the project and changed these lines to make those issues go away.

**Example**  
Please describe how we can try out your changes  
1. Create a React component that takes a Property (like a string array)
2. Build the direflow bundle
3. include the direflow bundle in the html
4. using document.querySelector get the webcomponent & set a new array property value

**Version**  
3.0.3
