### PR TITLE
Webpack Overwrite Settings (Fix #46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 package-lock.json
 yarn.lock
 config-overrides.js
+config-overrides.d.ts
 
 # User-specific stuff
 .idea/**/workspace.xml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/config/config-overrides.ts
+++ b/packages/direflow-component/src/config/config-overrides.ts
@@ -11,7 +11,8 @@ interface IOptions {
 }
 
 export = function override(config: any, env: string, options?: IOptions): any {
-  const { filename = 'direflowBundle.js', chunkFilename = 'vendor.js' } = options || {};
+  const filename = options?.filename || 'direflowBundle.js';
+  const chunkFilename = options?.chunkFilename || 'vendor.js';
 
   const overridenConfig = {
     ...addWelcomeMessage(config, env),

--- a/packages/direflow-component/src/config/config-overrides.ts
+++ b/packages/direflow-component/src/config/config-overrides.ts
@@ -10,7 +10,7 @@ interface IOptions {
   chunkFilename?: string;
 }
 
-module.exports = function override(config: any, env: string, options?: IOptions): any {
+export = function override(config: any, env: string, options?: IOptions): any {
   const { filename = 'direflowBundle.js', chunkFilename = 'vendor.js' } = options || {};
 
   const overridenConfig = {

--- a/packages/direflow-component/src/config/config-overrides.ts
+++ b/packages/direflow-component/src/config/config-overrides.ts
@@ -6,11 +6,12 @@ import { resolve } from 'path';
 import { PromiseTask } from 'event-hooks-webpack-plugin/lib/tasks';
 
 interface IOptions {
-  filename: string
-  chunkFilename: string
+  filename?: string;
+  chunkFilename?: string;
 }
 
-module.exports = function override(config: any, env: string, { filename = 'direflowBundle.js', chunkFilename = 'vendor.js' }: IOptions): any {
+module.exports = function override(config: any, env: string, options?: IOptions): any {
+  const { filename = 'direflowBundle.js', chunkFilename = 'vendor.js' } = options || {};
 
   const overridenConfig = {
     ...addWelcomeMessage(config, env),
@@ -69,7 +70,7 @@ const overrideOutput = (output: any, { filename, chunkFilename }: IOptions) => {
 
   return {
     ...newOutput,
-    filename, chunkFilename
+    filename, chunkFilename,
   };
 };
 

--- a/scripts/buildAll.js
+++ b/scripts/buildAll.js
@@ -35,8 +35,18 @@ function build(dir) {
 
         console.log(`✓ config-overrides.js moved succesfully`);
       })
+
+      exec(`mv ${dir}/dist/config/config-overrides.d.ts ${dir}/config-overrides.d.ts`, (err) => {
+        if (err) {
+          console.log(`✗ failed to move config-overrides.d.ts`);
+          console.log(err);
+          return;
+        }
+
+        console.log(`✓ config-overrides.d.ts moved succesfully`);
+      })
     }
-    
+
     console.log(`✓ ${dir} build succesfully`);
     out && console.log(out);
   });

--- a/scripts/cleanupAll.js
+++ b/scripts/cleanupAll.js
@@ -25,7 +25,7 @@ function cleanDeps(dir) {
         console.log(err);
         return;
       }
-      
+
       console.log(`✓ ${dir}/yarn.lock is REMOVED`);
       out && console.log(out);
     });
@@ -78,8 +78,20 @@ function cleanDeps(dir) {
           console.log(err);
           return;
         }
-  
+
         console.log(`✓ ${dir}/config-overrides.js is REMOVED`);
+        out && console.log(out);
+      });
+    }
+    if (fs.existsSync(`${dir}/config-overrides.d.ts`)) {
+      exec(`rm ${dir}/config-overrides.d.ts`, (err, out) => {
+        if (err) {
+          console.log(`✗ ${dir}/config-overrides.d.ts FAILED to remove`);
+          console.log(err);
+          return;
+        }
+
+        console.log(`✓ ${dir}/config-overrides.d.ts is REMOVED`);
         out && console.log(out);
       });
     }

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
-    "direflow-component": "3.2.0"
+    "direflow-component": "3.2.1"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "direflow-component": "3.2.0",
+    "direflow-component": "3.2.1",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2"


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
fixes #46 

**Example**  
```js
module.exports = (config, env) => ({
  ...webpackConfig(config, env, {filename: 'myBundle.js'})
})
```

**Version**  
3.2.1
  
Did you remember to remember to update the version of Direflow as explained here:  
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version