### PR TITLE
Fixing minor inconsistencies + cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
-    "direflow-component": "3.2.6"
+    "direflow-component": "3.2.7"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "direflow-component": "3.2.6",
+    "direflow-component": "3.2.7",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2"


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Fixing race condition between the initial setting of properties and lazyloading of the web components.

The issue arises due to the fact that the web component is defined asynchronously, waiting for the polyfills to lazyload.
If the properties are set on the HTML Element before `define` has got the chance to invoke, the lifecycle methods doesn't get the chance to fire.

Therefore, we transfer any currently set properties from directly on the DOM node, if present.

**Verification**  
Please describe how we can try out your changes  
1. Create a new Direflow Setup.
2. Add a new 'componentTitle' as an attribute. See that it changes. 
3. Add a new 'componentTitle' as a property. See that it changes. (even if attribute has been set).
5. Create a timeout for some seconds and set the property again. See that it changes.

**Version**  
3.2.7 