### PR TITLE
Fixing racing + render issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,7 @@
     "arrow-body-style": "off",
     "object-curly-newline": "off",
     "lines-between-class-members": "off",
-    "linebreak-style": "off"
+    "linebreak-style": "off",
+    "no-prototype-builtins": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -63,7 +63,6 @@ class WebComponentFactory {
     await includePolyfills({ usesShadow: !!factory.shadow }, this.plugins);
 
     return class WebComponent extends HTMLElement {
-      private application: JSX.Element | undefined;
       private initialProperties = clonedeep<{ [key: string]: any }>(factory.componentProperties);
       private properties: { [key: string]: any } = {};
 
@@ -211,41 +210,29 @@ class WebComponentFactory {
        * Mount React App onto the Web Component
        */
       private mountReactApp(options?: { initial: boolean }): void {
-        const application = this.getApplication();
-
-        if (!factory.shadow) {
-          ReactDOM.render(application, this);
-        } else {
-          let currentChildren: Node[] | undefined;
-
-          if (options?.initial) {
-            currentChildren = Array.from(this.children).map((child: Node) => child.cloneNode(true));
-          }
-
-          const root = createProxyRoot(this);
-          ReactDOM.render(<root.open>{application}</root.open>, this);
-
-          if (currentChildren) {
-            currentChildren.forEach((child: Node) => this.append(child));
-          }
-        }
-      }
-
-      /**
-       * Create the React App
-       */
-      private getApplication(): JSX.Element {
-        if (this.application) {
-          return this.application;
-        }
-
-        const baseApplication = (
+        const application = (
           <EventProvider value={this.eventDispatcher}>
             {React.createElement(factory.rootComponent, this.reactProps())}
           </EventProvider>
         );
 
-        return baseApplication;
+        if (!factory.shadow) {
+          ReactDOM.render(application, this);
+          return;
+        }
+
+        let currentChildren: Node[] | undefined;
+
+        if (options?.initial) {
+          currentChildren = Array.from(this.children).map((child: Node) => child.cloneNode(true));
+        }
+
+        const root = createProxyRoot(this);
+        ReactDOM.render(<root.open>{application}</root.open>, this);
+
+        if (currentChildren) {
+          currentChildren.forEach((child: Node) => this.append(child));
+        }
       }
 
       /**

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -142,11 +142,18 @@ class WebComponentFactory {
             enumerable: true,
 
             get(): any {
-              return self.properties[key] || self.initialProperties[key];
+              const currentValue = self.properties.hasOwnProperty(key)
+                ? self.properties[key]
+                : self.initialProperties[key];
+
+              return currentValue;
             },
 
             set(newValue: any): any {
-              const oldValue = self.properties[key] || self.initialProperties[key];
+              const oldValue = self.properties.hasOwnProperty(key)
+                ? self.properties[key]
+                : self.initialProperties[key];
+
               self.propertyChangedCallback(key, oldValue, newValue);
             },
           };
@@ -160,7 +167,7 @@ class WebComponentFactory {
        */
       private syncronizePropertiesAndAttributes(): void {
         Object.keys(this.initialProperties).forEach((key: string) => {
-          if (this.properties[key] !== undefined) {
+          if (this.properties.hasOwnProperty(key)) {
             return;
           }
 
@@ -183,7 +190,7 @@ class WebComponentFactory {
         const self: any = this;
 
         Object.keys(self.initialProperties).forEach((key: string) => {
-          if (self[key]) {
+          if (self.hasOwnProperty(key)) {
             self.properties[key] = self[key];
           }
         });

--- a/packages/direflow-component/src/services/proxyRoot.tsx
+++ b/packages/direflow-component/src/services/proxyRoot.tsx
@@ -31,12 +31,20 @@ const createProxyComponent = (options: IComponentOptions) => {
   return ShadowRoot;
 };
 
+const componentMap = new WeakMap<Element, React.FC<IShadowComponent>>();
+
 const createProxyRoot = (root: Element) => {
   return new Proxy<any>(
     {},
     {
       get(_: unknown, name: 'open' | 'closed'): any {
-        return createProxyComponent({ root, mode: name });
+        if (componentMap.get(root)) {
+          return componentMap.get(root);
+        }
+
+        const proxyComponent = createProxyComponent({ root, mode: name });
+        componentMap.set(root, proxyComponent);
+        return proxyComponent;
       },
     },
   );

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
-    "direflow-component": "3.2.6"
+    "direflow-component": "3.2.7"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/.eslintrc
+++ b/templates/ts/.eslintrc
@@ -28,6 +28,8 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "interface-name-prefix": "off",
+    "@typescript-eslint/explicit-function-return-type": "off"
   }
 }

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "direflow-component": "3.2.6",
+    "direflow-component": "3.2.7",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2"


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
- Fixing race condition between the initial setting of properties and lazyloading of the web components.
- Fixing issues with reinstantiating react root component. (This used to work, but a bug has been introduced recently).

The issue arises due to the fact that the web component is defined asynchronously, waiting for the polyfills to lazyload.
If the properties are set on the HTML Element before `define` has got the chance to invoke, the lifecycle methods doesn't get the chance to fire.

Therefore, we transfer any currently set properties from directly on the DOM node, if present.
Additionally, a reference to an already created proxy-root is cached in a weakmap.

**Verification**  
Please describe how we can try out your changes  
1. Create a new Direflow Setup.
2. Add a new 'componentTitle' as an attribute. See that it changes. 
3. Add a new 'componentTitle' as a property. See that it changes. (even if attribute has been set).
5. Create a timeout for some seconds and set the property again. See that it changes.
6. Turn on "Paint flashing" in dev tools. See that it only rerenders where it should (image 2 below)

**Screenshots**
![](https://drive.google.com/uc?export=view&id=1K3EYVvNnlhBdGt1P_WVb3iNy7SroCQfW)

![](https://drive.google.com/uc?export=view&id=14sSyvm7nYQia-sgKit5Edo4hygNAqkHd)

**Version**  
3.2.7 