### PR TITLE
Feature/lazyload react

### DIFF
--- a/cli/checkForUpdate.ts
+++ b/cli/checkForUpdate.ts
@@ -8,7 +8,7 @@ const checkForUpdates = () => {
   const currentVersion = buffer.toString('utf8');
 
   if (rootPackage.version.trim() !== currentVersion.trim()) {
-    return chalk.grey(updateAvailable(rootPackage.version.trim(), currentVersion.trim()));
+    return chalk.white(updateAvailable(rootPackage.version.trim(), currentVersion.trim()));
   }
 
   return '';

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -23,6 +23,7 @@
     "event-hooks-webpack-plugin": "2.1.4",
     "lodash.clonedeep": "^4.5.0",
     "node-sass": "^4.13.0",
+    "handlebars": "^4.7.2",
     "rimraf": "3.0.0",
     "style-it": "2.1.4",
     "to-string-loader": "1.1.5",

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -20,7 +20,6 @@
   "homepage": "https://direflow.io",
   "dependencies": {
     "@svgr/webpack": "4.3.2",
-    "@types/webfontloader": "^1.6.29",
     "event-hooks-webpack-plugin": "2.1.4",
     "lodash.clonedeep": "^4.5.0",
     "node-sass": "^4.13.0",
@@ -31,6 +30,7 @@
     "webpack-filter-warnings-plugin": "^1.2.1"
   },
   "devDependencies": {
+    "@types/webfontloader": "^1.6.29",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",

--- a/packages/direflow-component/src/DireflowComponent.tsx
+++ b/packages/direflow-component/src/DireflowComponent.tsx
@@ -3,7 +3,7 @@ import includePolyfills from './services/polyfillHandler';
 
 class DireflowComponent {
   private componentProperties?: { [key: string]: unknown };
-  private rootComponent?: React.FC | React.ComponentClass;
+  private rootComponent?: React.FC<any> | React.ComponentClass<any, any>;
   private WebComponent?: typeof HTMLElement;
   private elementName?: string;
   private plugins?: IDireflowPlugin[];
@@ -24,7 +24,7 @@ class DireflowComponent {
    * Create Direflow Component
    * @param App React Component
    */
-  public create(App: React.FC | React.ComponentClass): Promise<HTMLElement> {
+  public create(App: React.FC<any> | React.ComponentClass<any, any>): Promise<HTMLElement> {
     return new Promise(async (resolve, reject) => {
       this.rootComponent = App;
 

--- a/packages/direflow-component/src/DireflowComponent.tsx
+++ b/packages/direflow-component/src/DireflowComponent.tsx
@@ -1,4 +1,5 @@
 import WebComponentFactory from './WebComponentFactory';
+import includePolyfills from './services/polyfillHandler';
 
 class DireflowComponent {
   private componentProperties: any | undefined;
@@ -39,7 +40,11 @@ class DireflowComponent {
         resolve(element);
       };
 
-      this.WebComponent = await new WebComponentFactory(
+      await Promise.all([
+        includePolyfills({ usesShadow: !!this.shadow }, this.plugins),
+      ]);
+
+      this.WebComponent = new WebComponentFactory(
         this.componentProperties || {},
         this.rootComponent,
         this.shadow,

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -6,7 +6,6 @@ import createProxyRoot from './services/proxyRoot';
 import addStyledComponentStyles from './services/styledComponentsHandler';
 import includeExternalSources from './services/externalSourceHandler';
 import loadFonts from './services/fontLoaderHandler';
-import includePolyfills from './services/polyfillHandler';
 import includeGoogleIcons from './services/iconLoaderHandler';
 import { EventProvider } from './components/EventContext';
 
@@ -39,14 +38,8 @@ class WebComponentFactory {
   /**
    * Create new class that will serve as the Web Component.
    */
-  public async create() {
+  public create() {
     const factory = this;
-
-    /**
-     * Wait for Web Component polyfills to be included in the host application.
-     * Polyfill scripts are loaded async.
-     */
-    await includePolyfills({ usesShadow: !!factory.shadow }, this.plugins);
 
     return class WebComponent extends HTMLElement {
       public initialProperties = clonedeep(factory.componentProperties);

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -12,7 +12,7 @@ import { EventProvider } from './components/EventContext';
 class WebComponentFactory {
   constructor(
     private componentProperties: { [key: string]: unknown },
-    private rootComponent: React.FC | React.ComponentClass,
+    private rootComponent: React.FC<any> | React.ComponentClass<any, any>,
     private shadow?: boolean,
     private plugins?: IDireflowPlugin[],
     private connectCallback?: (element: HTMLElement) => void,

--- a/packages/direflow-component/src/config/config-overrides.ts
+++ b/packages/direflow-component/src/config/config-overrides.ts
@@ -10,24 +10,29 @@ export = function override(config: TConfig, env: string, options?: IOptions) {
   const chunkFilename = options?.chunkFilename || 'vendor.js';
 
   const overridenConfig = {
-    ...addWelcomeMessage(config, env),
+    ...addEntries(config, env),
     module: overrideModule(config.module),
     output: overrideOutput(config.output, { filename, chunkFilename }),
     optimization: overrideOptimization(config.optimization, env),
     resolve: overrideResolve(config.resolve),
     plugins: overridePlugins(config.plugins, env, { filename, chunkFilename }),
+    externals: overrideExternals(config.externals, env),
   };
 
   return overridenConfig;
 };
 
-function addWelcomeMessage(config: TConfig, env: string) {
-  if (env === 'production') {
-    return config;
+function addEntries(config: TConfig, env: string) {
+  let entry: string[] = [];
+
+  if (env === 'development') {
+    entry = [...config.entry, resolve(__dirname, './dist/config/welcome.js')];
   }
 
-  const entry = [...config.entry];
-  entry.push(resolve(__dirname, './dist/config/welcome.js'));
+  if (env === 'production') {
+    entry = [resolve(__dirname, './dist/config/entryLoader.js')];
+  }
+
   config.entry = entry;
 
   return config;
@@ -111,6 +116,18 @@ function overrideResolve(currentResolve: IResolve) {
   );
 
   return currentResolve;
+}
+
+function overrideExternals(externals: any, env: string) {
+  if (env === 'development') {
+    return externals;
+  }
+
+  return {
+    ...externals,
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  };
 }
 
 async function copyBundleScript(env: string, { filename, chunkFilename }: IOptions) {

--- a/packages/direflow-component/src/config/config-overrides.ts
+++ b/packages/direflow-component/src/config/config-overrides.ts
@@ -125,7 +125,7 @@ function overrideResolve(currentResolve: IResolve) {
   return currentResolve;
 }
 
-function overrideExternals(externals: any, env: string) {
+function overrideExternals(externals: { [key: string]: any }, env: string) {
   if (env === 'development') {
     return externals;
   }

--- a/packages/direflow-component/src/config/config-overrides.ts
+++ b/packages/direflow-component/src/config/config-overrides.ts
@@ -1,6 +1,7 @@
 import EventHooksPlugin from 'event-hooks-webpack-plugin';
 import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 import rimraf from 'rimraf';
+import handlebars from 'handlebars';
 import fs from 'fs';
 import { resolve } from 'path';
 import { PromiseTask } from 'event-hooks-webpack-plugin/lib/tasks';
@@ -30,6 +31,12 @@ function addEntries(config: TConfig, env: string) {
   }
 
   if (env === 'production') {
+    const [pathIndex] = config.entry;
+    const entryLoaderFile = fs.readFileSync(resolve(__dirname, './dist/config/entryLoader.js'), 'utf8');
+    const entryLoaderTemplate = handlebars.compile(entryLoaderFile);
+    const entryLoaderFileNew = entryLoaderTemplate({ pathIndex });
+    fs.writeFileSync(resolve(__dirname, './dist/config/entryLoader.js'), entryLoaderFileNew);
+
     entry = [resolve(__dirname, './dist/config/entryLoader.js')];
   }
 

--- a/packages/direflow-component/src/config/entryLoader.ts
+++ b/packages/direflow-component/src/config/entryLoader.ts
@@ -24,19 +24,13 @@ const includeReact = async () => {
 
 const includeIndex = () => {
   try {
-    require('../../../../src/index.js');
+    require('{{pathIndex}}');
   } catch (error) {
-    // Ignore if file doens't exits
-  }
-
-  try {
-    require('../../../../src/index.tsx');
-  } catch (error) {
-    // Ignore if file doens't exits
+    console.warn('No index-file was found. Did you move the index-file from src?');
   }
 };
 
-(async () => {
+setTimeout(async () => {
   if (window.React && window.ReactDOM) {
     includeIndex();
     return;
@@ -44,14 +38,26 @@ const includeIndex = () => {
 
   await includeReact();
 
-  await new Promise((resolve) => {
-    const interval = setInterval(() => {
-      if (window.React && window.ReactDOM) {
-        clearInterval(interval);
-        resolve();
-      }
-    });
-  });
+  try {
+    await new Promise((resolve, reject) => {
+      let intervalCounts = 0;
 
-  includeIndex();
-})();
+      const interval = setInterval(() => {
+        if (intervalCounts >= 2500) {
+          reject(new Error('Direflow Error: React & ReactDOM was unable to load'));
+        }
+
+        if (window.React && window.ReactDOM) {
+          clearInterval(interval);
+          resolve();
+        }
+
+        intervalCounts += 1;
+      });
+    });
+
+    includeIndex();
+  } catch (error) {
+    console.error(error.message);
+  }
+});

--- a/packages/direflow-component/src/config/entryLoader.ts
+++ b/packages/direflow-component/src/config/entryLoader.ts
@@ -1,0 +1,57 @@
+import asyncScriptLoader from '../services/asyncScriptLoader';
+
+let didIncludeReactOnce = false;
+
+const includeReact = async () => {
+  if (didIncludeReactOnce) {
+    return;
+  }
+
+  try {
+    await asyncScriptLoader(
+      'https://unpkg.com/react@16/umd/react.production.min.js',
+      window.reactBundleLoaded,
+    );
+    await asyncScriptLoader(
+      'https://unpkg.com/react-dom@16/umd/react-dom.production.min.js',
+      window.reactBundleLoaded,
+    );
+    didIncludeReactOnce = true;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const includeIndex = () => {
+  try {
+    require('../../../../src/index.js');
+  } catch (error) {
+    // Ignore if file doens't exits
+  }
+
+  try {
+    require('../../../../src/index.tsx');
+  } catch (error) {
+    // Ignore if file doens't exits
+  }
+};
+
+(async () => {
+  if (window.React && window.ReactDOM) {
+    includeIndex();
+    return;
+  }
+
+  await includeReact();
+
+  await new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (window.React && window.ReactDOM) {
+        clearInterval(interval);
+        resolve();
+      }
+    });
+  });
+
+  includeIndex();
+})();

--- a/packages/direflow-component/src/services/asyncScriptLoader.ts
+++ b/packages/direflow-component/src/services/asyncScriptLoader.ts
@@ -1,0 +1,50 @@
+type TBundle = { script: Element; hasLoaded: boolean };
+declare global {
+  interface Window {
+    wcPolyfillsLoaded: TBundle[];
+    reactBundleLoaded: TBundle[];
+  }
+}
+
+const asyncScriptLoader = (src: string, bundleList: TBundle[] | undefined): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = src;
+
+    if (!bundleList) {
+      bundleList = [];
+    }
+
+    const existingPolyfill = bundleList.find((loadedScript) => {
+      return loadedScript.script.isEqualNode(script);
+    });
+
+    if (existingPolyfill) {
+      if (existingPolyfill.hasLoaded) {
+        resolve();
+      }
+
+      existingPolyfill.script.addEventListener('load', () => resolve());
+      return;
+    }
+
+    const scriptEntry = {
+      script,
+      hasLoaded: false,
+    };
+
+    bundleList.push(scriptEntry);
+
+    script.addEventListener('load', () => {
+      scriptEntry.hasLoaded = true;
+      resolve();
+    });
+
+    script.addEventListener('error', () => reject(new Error('Polyfill failed to load')));
+
+    document.head.appendChild(script);
+  });
+};
+
+export default asyncScriptLoader;

--- a/packages/direflow-component/src/services/polyfillHandler.ts
+++ b/packages/direflow-component/src/services/polyfillHandler.ts
@@ -2,6 +2,10 @@ import asyncScriptLoader from './asyncScriptLoader';
 
 let didIncludeOnce = false;
 
+const DEFAULT_SD = 'https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.4.1/bundles/webcomponents-sd.js';
+const DEFAULT_CE = 'https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.4.1/bundles/webcomponents-ce.js';
+const DEFAULT_AD = 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.4.1/custom-elements-es5-adapter.js';
+
 const includePolyfills = async (
   options: { usesShadow: boolean },
   plugins: IDireflowPlugin[] | undefined,
@@ -10,19 +14,36 @@ const includePolyfills = async (
     return;
   }
 
+  const scriptsList = [];
+
+  let useSD = '';
+  let useCE = '';
+  let useAD = '';
+
   const polyfillLoaderPlugin = plugins?.find((plugin) => plugin.name === 'polyfill-loader');
 
-  if (polyfillLoaderPlugin) {
-    includePolyfillsFromPlugin(polyfillLoaderPlugin);
-    return;
+  if (polyfillLoaderPlugin?.options?.use.sd) {
+    useSD = typeof polyfillLoaderPlugin.options?.use.sd === 'string'
+      ? polyfillLoaderPlugin.options?.use.sd
+      : DEFAULT_SD;
   }
 
-  const scriptsList = [];
+  if (polyfillLoaderPlugin?.options?.use.ce) {
+    useCE = typeof polyfillLoaderPlugin.options?.use.ce === 'string'
+      ? polyfillLoaderPlugin.options?.use.ce
+      : DEFAULT_CE;
+  }
+
+  if (polyfillLoaderPlugin?.options?.use.adapter) {
+    useAD = typeof polyfillLoaderPlugin.options?.use.adapter === 'string'
+      ? polyfillLoaderPlugin.options.use.adapter
+      : DEFAULT_AD;
+  }
 
   if (options.usesShadow) {
     scriptsList.push(
       asyncScriptLoader(
-        'https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.4.1/bundles/webcomponents-sd.js',
+        useSD || DEFAULT_SD,
         window.wcPolyfillsLoaded,
       ),
     );
@@ -30,14 +51,14 @@ const includePolyfills = async (
 
   scriptsList.push(
     asyncScriptLoader(
-      'https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.4.1/bundles/webcomponents-ce.js',
+      useCE || DEFAULT_CE,
       window.wcPolyfillsLoaded,
     ),
   );
 
   scriptsList.push(
     asyncScriptLoader(
-      'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.4.1/custom-elements-es5-adapter.js',
+      useAD || DEFAULT_AD,
       window.wcPolyfillsLoaded,
     ),
   );
@@ -45,48 +66,6 @@ const includePolyfills = async (
   try {
     await Promise.all(scriptsList);
     didIncludeOnce = true;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-let didIncludeOncePlugin = false;
-
-const includePolyfillsFromPlugin = async (plugin: IDireflowPlugin) => {
-  if (didIncludeOncePlugin) {
-    return;
-  }
-
-  const scriptsList = [];
-
-  if (plugin.options?.use.sd) {
-    const src =
-      typeof plugin.options?.use.sd === 'string'
-        ? plugin.options?.use.sd
-        : 'https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.4.1/bundles/webcomponents-sd.js';
-
-    scriptsList.push(asyncScriptLoader(src, window.wcPolyfillsLoaded));
-  }
-
-  if (plugin.options?.use.ce) {
-    const src =
-      typeof plugin.options?.use.ce === 'string'
-        ? plugin.options?.use.ce
-        : 'https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.4.1/bundles/webcomponents-ce.js';
-
-    scriptsList.push(asyncScriptLoader(src, window.wcPolyfillsLoaded));
-  }
-
-  const adapterSrc =
-    typeof plugin.options?.use.adapter === 'string'
-      ? plugin.options.use.adapter
-      : 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.4.1/custom-elements-es5-adapter.js';
-
-  scriptsList.push(asyncScriptLoader(adapterSrc, window.wcPolyfillsLoaded));
-
-  try {
-    await Promise.all(scriptsList);
-    didIncludeOncePlugin = true;
   } catch (error) {
     console.error(error);
   }

--- a/packages/direflow-component/src/types/ConfigOverrides.d.ts
+++ b/packages/direflow-component/src/types/ConfigOverrides.d.ts
@@ -54,4 +54,5 @@ type TConfig = {
   optimization: IOptimization;
   plugins: IPlugin[];
   resolve: IResolve;
+  externals: { [key: string]: any };
 };

--- a/scripts/bash/setupLocal.sh
+++ b/scripts/bash/setupLocal.sh
@@ -1,4 +1,4 @@
 npm -g remove direflow-cli
 npm run update-version link
 npm link
-npm run build-link
+npm run build:full


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Lazyloading of React and ReactDOM modules in production.

As a part of the production build, React and ReactDOM will be extracted from the bundle, reducing the initial bundle size of the sample component to only **49KB**

React and ReactDOM will be lazyloaded from CDN, and the Direflow Component will render once the React and ReactDOM modules are ready.
This means, that the direflowBundle will no longer be render-blocking in any way when included in a host application.

Additionally, if React and ReactDOM are already included in the host application, Direflow will simply "hook into" these modules instead, and skip loading altogether.
This introduces a **major** performance improvement.

Running Direflow in development mode will remain as is; React and ReactDOM will still be included from node_modules.

**How did you verify that your changes work as expected? Please describe**  
I verified that the Direflow Component works in both development and production mode.

**Example**  
Please describe how we can try out your changes  
1. Create a new Direflow Setup.
2. Start the dev-server and verify that the Direflow Component renders.
3. Build the direflowBundle.
4. See that the /build/direflowBundle.js file is not exceeding 50KB.
5. Include the /build/direflowBundle.js file in another index.html file somewhere, and add the custom element to the body.
6. Open this index.html file in the browser and verify that the Direflow Component renders.
7. Go and inspect the DOM - see that the React and ReactDOM bundles are included in the header as an external script.

**Version**  
3.3.0