### PR TITLE
Handle Material UI as plugin when shadowRoot is activated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.3.0",
+  "version": "3.3.2",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.3.0",
+  "version": "3.3.2",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -9,6 +9,7 @@ import loadFonts from './services/fontLoaderHandler';
 import includeGoogleIcons from './services/iconLoaderHandler';
 import { EventProvider } from './components/EventContext';
 import { IDireflowPlugin } from './types/DireflowConfig';
+import handleMaterialUiStyle from './services/materialUiStylesHandler';
 
 class WebComponentFactory {
   constructor(
@@ -207,8 +208,9 @@ class WebComponentFactory {
           currentChildren = Array.from(this.children).map((child: Node) => child.cloneNode(true));
         }
 
-        const root = createProxyRoot(this);
-        ReactDOM.render(<root.open>{application}</root.open>, this);
+        const wrappedAppAndMountPoint = handleMaterialUiStyle(application, factory.plugins);
+        const root = createProxyRoot(this, wrappedAppAndMountPoint.mountPoint);
+        ReactDOM.render(<root.open>{wrappedAppAndMountPoint.app}</root.open>, this);
 
         if (currentChildren) {
           currentChildren.forEach((child: Node) => this.append(child));

--- a/packages/direflow-component/src/services/materialUiStylesHandler.tsx
+++ b/packages/direflow-component/src/services/materialUiStylesHandler.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { IDireflowPlugin } from '../types/DireflowConfig';
+
+const handleMaterialUiStyle = (app: React.FC<any> | React.ComponentClass<any, any>, plugins: IDireflowPlugin[] | undefined)
+    : { mountPoint?: Element, app: React.FC<any> | React.ComponentClass<any, any> } => {
+
+    if (plugins?.find((plugin) => plugin.name === 'material-ui')) {
+        try {
+            const jssLib = require('jss');
+            const materialUiStyles = require('@material-ui/core/styles');
+            const { create } = jssLib;
+            const { jssPreset } = materialUiStyles;
+            const { StylesProvider } = materialUiStyles;
+
+            const mountPoint = document.createElement('span');
+
+            const jss = create({
+                ...jssPreset(),
+                insertionPoint: mountPoint
+            });
+
+            return { mountPoint, app: (<StylesProvider jss={jss}>{app}</StylesProvider>) };
+        } catch(err) {
+            console.error("Could not load Material-UI, not using them...", err);
+            return { app };
+        }
+    }
+    else {
+        return { app };
+    }
+};
+
+export default handleMaterialUiStyle;

--- a/packages/direflow-component/src/services/proxyRoot.tsx
+++ b/packages/direflow-component/src/services/proxyRoot.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { createPortal } from 'react-dom';
 
 interface IShadowContent {
-  root: ShadowRoot;
+  root: ShadowRoot | Element;
   children: React.ReactNode;
 }
 
@@ -13,6 +13,7 @@ interface IShadowComponent {
 interface IComponentOptions {
   root: Element;
   mode: 'open' | 'closed';
+  mountPoint?: Element;
 }
 
 const ShadowContent: FC<IShadowContent> = (props) => {
@@ -22,8 +23,12 @@ const ShadowContent: FC<IShadowContent> = (props) => {
 
 const createProxyComponent = (options: IComponentOptions) => {
   const ShadowRoot: FC<IShadowComponent> = (props) => {
-    const shadowedRoot = options.root.shadowRoot
+    let shadowedRoot: ShadowRoot | Element = options.root.shadowRoot
     || options.root.attachShadow({ mode: options.mode });
+
+    if (options.mountPoint) {
+      shadowedRoot = shadowedRoot.appendChild(options.mountPoint);
+    }
 
     return <ShadowContent root={shadowedRoot}>{props.children}</ShadowContent>;
   };
@@ -33,7 +38,7 @@ const createProxyComponent = (options: IComponentOptions) => {
 
 const componentMap = new WeakMap<Element, React.FC<IShadowComponent>>();
 
-const createProxyRoot = (root: Element): { [key in 'open' | 'closed']: React.FC<IShadowComponent> } => {
+const createProxyRoot = (root: Element, mountPoint?: Element): { [key in 'open' | 'closed']: React.FC<IShadowComponent> } => {
   return new Proxy<any>(
     {},
     {
@@ -42,7 +47,7 @@ const createProxyRoot = (root: Element): { [key in 'open' | 'closed']: React.FC<
           return componentMap.get(root);
         }
 
-        const proxyComponent = createProxyComponent({ root, mode: name });
+        const proxyComponent = createProxyComponent({ root, mode: name , mountPoint});
         componentMap.set(root, proxyComponent);
         return proxyComponent;
       },

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
-    "direflow-component": "3.3.0"
+    "direflow-component": "3.3.2"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "direflow-component": "3.3.0",
+    "direflow-component": "3.3.2",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2"


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Handle Material UI styles to include them inside the shadow root of the webcomponent.

Use of JSS to do so with a StylesProvider wrapping element around the app.
-  in case useShadow is false, same behavior as before
-  in case useShadow is true but 'material-ui' plugin is not added, no wrapping, same behavior as before
-  in case useShadow is true and 'material-ui' plugin is added, wrapp app, add a mounting point to be included inside the shadowRoot, then React ShadowContent is added inside this mounting point rather than directly in the shadow root.

**How did you verify that your changes work as expected? Please describe**  
As shown afterwards with screenshots:
-  when there is no plugin "material-ui", then a raw button is displayed when using material-ui button.
-  when there is a plugin "material-ui", then a material styled button is displayed.

**Example**  
1.  Install direflkow globally
2.  Create a webcomponent with direflow: `direflow create`
3.  Follow instructions [here](https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version)
4.  Install material-ui library in the webcomponent: `yarn add @material-ui/core`
5.  Add material-ui plugin in webcomponent by modifying index.tsx. In direflowPlugins, add `{ name; "material-ui" }`
6.  Add a Material UI button in App.tsx:
```
import Button from '@material-ui/core/Button';
...
<Button variant="contained" color="primary">
   My Material UI Button
</Button>
```
7.  Serve the webcomponent `yarn start`
8.  Button appears with material-ui style and styles can be found in shadowRoot of the webcomponent

**Screenshots**  
Before:
![image](https://user-images.githubusercontent.com/64207/75654382-e44b2580-5c5f-11ea-88c6-7692f8bdedfa.png)

After:
![image](https://user-images.githubusercontent.com/64207/75654344-d1d0ec00-5c5f-11ea-9387-7f3e7b642390.png)

**Version**  
Based on version 3.3.0, upgraded to 3.4.0 with `yarn update-version 3.4.0`.

**NB**
Documentation will have to be updated to describe this new plugin usage.