### PR TITLE
Fixes #93 : material ui render later issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -208,7 +208,7 @@ class WebComponentFactory {
           currentChildren = Array.from(this.children).map((child: Node) => child.cloneNode(true));
         }
 
-        const wrappedAppAndMountPoint = handleMaterialUiStyle(application, factory.plugins);
+        const wrappedAppAndMountPoint = handleMaterialUiStyle(this, application, factory.plugins);
         const root = createProxyRoot(this, wrappedAppAndMountPoint.mountPoint);
         ReactDOM.render(<root.open>{wrappedAppAndMountPoint.app}</root.open>, this);
 

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
-    "direflow-component": "3.3.2"
+    "direflow-component": "3.3.3"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "direflow-component": "3.3.2",
+    "direflow-component": "3.3.3",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2"


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Fixes #93 issue + better naming in proxyRoot for styles container and renamed some variables and classes in proxy root for a better understanding (for instance, "root" is  the webcomponent, "ShadowContent" is actually a Portal).

Explanations about the issue:
I've found out the issue was due to 2 behaviors :
- unwrapping JSS insertion point while it was necessary (app not wrapped inside though, the span lives as a sibling of the app)
- multiple calls to mountReactApp which were changing jss insertion point (created multiple times as called multiple times) while proxy root was using a cache without rendering jss insertion point again => JSS insertion point provided to the app was not the DOM element anymore.

**How did you verify that your changes work as expected? Please describe**  
No regressions thanks to Cypress and jest.

Tested with an app containing material ui with a second component loaded after having clicked on a button, as described in the example below.

**Example**  
Please describe how we can try out your changes  
1. Follow documentation about material-ui plugin
2. In App.tsx, add the following code:
```
// App.tsx
...
  const [otherComponentShown, setOtherComponentShown] = React.useState(false);
  const handleShowOtherComponentClick = () => {
    setOtherComponentShown(true);
  }
return (
...
<div>
              <Button onClick={handleShowOtherComponentClick} variant='contained' color='primary'>Show</Button>
              {otherComponentShown ? (<OtherComponent></OtherComponent>) : ('')}
</div>
...
```
3. Add an OtherComponent.tsx with the following code:
```
// OtherComponent.tsx
import React, {FC} from 'react';
import { makeStyles } from '@material-ui/core';
const useStyles = makeStyles({
    red: { backgroundColor: 'red' }
});
interface IProps {}
const OtherComponent: FC<IProps> = () => {
    const classes = useStyles();
    return <div className={classes.red}>
        Displayed in red background
    </div>
};
export default OtherComponent;
```
4. Run, click on the button

**Version**  
Version 3.3.3. (fix of version 3.3.2)