### PR TITLE
Fixes #122 about IE11 support for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/helpers/proxyRoot.tsx
+++ b/packages/direflow-component/src/helpers/proxyRoot.tsx
@@ -43,7 +43,7 @@ const createProxyRoot = (
   shadowChildren: Element[],
 ): { [key in 'open' | 'closed']: React.FC<IShadowComponent> } => {
   return new Proxy<any>(
-    {},
+    { open: null, closed: null },
     {
       get(_: unknown, mode: 'open' | 'closed') {
         if (componentMap.get(webComponent)) {

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.9",
-    "direflow-scripts": "3.4.9"
+    "direflow-component": "3.4.10",
+    "direflow-scripts": "3.4.10"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.9",
-    "direflow-scripts": "3.4.9"
+    "direflow-component": "3.4.10",
+    "direflow-scripts": "3.4.10"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Fixes IE11 support due to Proxypolyfill requiring attribute on which a getter is provided.

**How did you verify that your changes work as expected? Please describe**  
Tested on IE11 after a production build.

**Example**  
Please describe how we can try out your changes  
1. Locally update direflow on your project and follow new [documentation](https://github.com/nicocunin/direflow-docs/commit/8be13c97f8086e353b04cef7fadaf2de4ca5379c) for IE 11 support
2. `yarn build`
3. Serve the index.html
4. In IE 11 start the webcomponent

**Version**  
Upgraded to 3.4.10 (patch + 1)
  
Did you remember to update the version of Direflow as explained here:  
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version