### PR TITLE
Fixes #121

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.4.11",
+  "version": "3.4.13",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.4.11",
+  "version": "3.4.13",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/plugins/materialUiPlugin.tsx
+++ b/packages/direflow-component/src/plugins/materialUiPlugin.tsx
@@ -13,7 +13,6 @@ const materialUiPlugin: PluginRegistrator = (
     try {
       const { create } = require('jss');
       const { jssPreset, StylesProvider } = require('@material-ui/core/styles');
-
       const insertionPoint = document.createElement('span');
       insertionPoint.id = 'direflow_material-ui-styles';
 
@@ -28,7 +27,7 @@ const materialUiPlugin: PluginRegistrator = (
         jssCache.set(element, jss);
       }
 
-      return [<StylesProvider jss={jss}>{app}</StylesProvider>, insertionPoint];
+      return [<StylesProvider jss={jss} sheetsManager={new Map()}>{app}</StylesProvider>, insertionPoint];
     } catch (err) {
       console.error('Could not load Material-UI. Did you remember to install @material-ui/core?');
     }

--- a/packages/direflow-component/tsconfig.json
+++ b/packages/direflow-component/tsconfig.json
@@ -2,7 +2,12 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "esNext",
-    "lib": ["es2017", "es7", "es6", "dom"],
+    "lib": [
+      "es2017",
+      "es7",
+      "es6",
+      "dom"
+    ],
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "src",
@@ -10,7 +15,10 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "node_modules",

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.4.11",
+  "version": "3.4.13",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.11",
-    "direflow-scripts": "3.4.11"
+    "direflow-component": "3.4.13",
+    "direflow-scripts": "3.4.13"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.11",
-    "direflow-scripts": "3.4.11"
+    "direflow-component": "3.4.13",
+    "direflow-scripts": "3.4.13"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Fixes #121 : one sheets manager per webcomponents to avoid cash to happen between webcomponents.

**How did you verify that your changes work as expected? Please describe**  
Tested it with my app, duplicating the custom element tag in index.html

**Example**  
1. Create a new webcomponent with direflow
2. Modify index.html and duplicate custom element tag
2. `yarn build`
3. Both components get properly loaded

**Version**  
3.4.12

**NB**
To have the build pass for `packages/direflow-component` I had to modify `tsconfig.json` to add `"types": [ "node"]` because `tsc` was discovering issues with `jest-diff` types from `../../node_modules`...