### PR TITLE
Feature/external loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {
@@ -54,7 +54,7 @@
     "ncp": "2.0.0",
     "rimraf": "3.0.0",
     "to-case": "^2.0.0",
-    "typescript": "^3.7.0"
+    "typescript": "3.9.3"
   },
   "devDependencies": {
     "@types/inquirer": "6.5.0",

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",
@@ -28,7 +28,7 @@
     "@types/react": "16.9.25",
     "@types/react-dom": "16.9.5",
     "@types/webfontloader": "1.6.29",
-    "typescript": "3.7.2"
+    "typescript": "3.9.3"
   },
   "peerDependencies": {
     "react": "16.13.1",

--- a/packages/direflow-component/src/hooks/useExternalSource.ts
+++ b/packages/direflow-component/src/hooks/useExternalSource.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+type TSource = {
+  [key: string]: {
+    state: 'loading' | 'completed';
+    callback?: Function | null;
+  };
+};
+
+declare global {
+  interface Window {
+    externalSourcesLoaded: TSource;
+  }
+}
+
+/**
+ * Hook into an external source given a path
+ * Returns whether the source is loaded or not
+ * @param source
+ */
+const useExternalSource = (source: string) => {
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  useEffect(() => {
+    if (window.externalSourcesLoaded[source].state === 'completed') {
+      setHasLoaded(true);
+      return;
+    }
+
+    window.externalSourcesLoaded[source].callback = () => {
+      setHasLoaded(true);
+    };
+  }, []);
+
+  return hasLoaded;
+};
+
+export default useExternalSource;

--- a/packages/direflow-component/src/index.ts
+++ b/packages/direflow-component/src/index.ts
@@ -1,6 +1,8 @@
 import DireflowComponent from './DireflowComponent';
 import DireflowConfiguration from './decorators/DireflowConfiguration';
 
+import useExternalSource from './hooks/useExternalSource';
+
 export { Styled, withStyles } from './components/Styled';
 export { EventProvider, EventConsumer, EventContext } from './components/EventContext';
-export { DireflowComponent, DireflowConfiguration };
+export { DireflowComponent, DireflowConfiguration, useExternalSource };

--- a/packages/direflow-component/src/plugins/externalLoaderPlugin.ts
+++ b/packages/direflow-component/src/plugins/externalLoaderPlugin.ts
@@ -30,14 +30,21 @@ const externalLoaderPlugin: PluginRegistrator = (
   const scriptTags: HTMLScriptElement[] = [];
   const styleTags: HTMLLinkElement[] = [];
 
-  paths.forEach((path: string | { src: string; async: boolean }) => {
+  paths.forEach((path: string | { src: string; async?: boolean; useHead?: boolean }) => {
     const actualPath = typeof path === 'string' ? path : path.src;
     const async = typeof path === 'string' ? false : path.async;
+    const useHead = typeof path === 'string' ? undefined : path.useHead;
 
     if (actualPath.endsWith('.js')) {
       const script = document.createElement('script');
       script.src = actualPath;
-      script.async = async;
+      script.async = !!async;
+
+      if (useHead !== undefined && !useHead) {
+        script.setAttribute('use-head', 'false');
+      } else {
+        script.setAttribute('use-head', 'true');
+      }
 
       scriptTags.push(script);
     }
@@ -47,16 +54,30 @@ const externalLoaderPlugin: PluginRegistrator = (
       link.rel = 'stylesheet';
       link.href = actualPath;
 
+      if (useHead) {
+        link.setAttribute('use-head', 'true');
+      } else {
+        link.setAttribute('use-head', 'false');
+      }
+
       styleTags.push(link);
     }
   });
+
+  const insertionPoint = document.createElement('span');
+  insertionPoint.id = 'direflow_external-sources';
 
   if (!window.externalSourcesLoaded) {
     window.externalSourcesLoaded = {};
   }
 
   scriptTags.forEach((script) => {
-    injectIntoHead(script);
+    if (script.getAttribute('use-head') === 'true') {
+      injectIntoHead(script);
+    } else {
+      insertionPoint.appendChild(script);
+    }
+
     window.externalSourcesLoaded[script.src] = {
       state: 'loading',
     };
@@ -67,11 +88,13 @@ const externalLoaderPlugin: PluginRegistrator = (
     });
   });
 
-  const insertionPoint = document.createElement('span');
-  insertionPoint.id = 'direflow_external-styles';
-
   styleTags.forEach((link) => {
-    insertionPoint.appendChild(link);
+    if (link.getAttribute('use-head') === 'true') {
+      injectIntoHead(link);
+    } else {
+      insertionPoint.appendChild(link);
+    }
+
     window.externalSourcesLoaded[link.href] = {
       state: 'loading',
     };

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",
@@ -42,6 +42,6 @@
     "@types/webfontloader": "1.6.29",
     "babel-loader": "8.1.0",
     "terser-webpack-plugin": "2.3.5",
-    "typescript": "3.7.2"
+    "typescript": "3.9.3"
   }
 }

--- a/packages/direflow-scripts/tsconfig.json
+++ b/packages/direflow-scripts/tsconfig.json
@@ -13,6 +13,7 @@
   },
   "exclude": [
     "node_modules",
+    "direflow-jest.config.js",
     "dist"
   ]
 }

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.13",
-    "direflow-scripts": "3.4.13"
+    "direflow-component": "3.4.14",
+    "direflow-scripts": "3.4.14"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.13",
-    "direflow-scripts": "3.4.13"
+    "direflow-component": "3.4.14",
+    "direflow-scripts": "3.4.14"
   },
   "devDependencies": {
     {{#if eslint}}
@@ -61,7 +61,7 @@
     "tslint-react": "4.1.0",
     "tslint": "5.20.0",
     {{/if}}
-    "typescript": "^3.7.0",
+    "typescript": "^3.9.3",
     "webpack-cli": "^3.3.11",
     "ts-loader": "^6.2.2"
   },


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
This introduces 2 new features in addition to the `external-loader` plugin.  
Is related to #137 

## useHead option in `external-loader`
The ability to use a `useHead` option on `external-loader` plugin.

```js
{
  name: 'external-loader',
  options: {
    paths: [
      {
        src: 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css',
        useHead: true, // <- This is the new option
      },
    ],
  },
},
```

When provided, styles will be injected into the `head` of the host application instead of inside the Web Component. Duplicates will automatically be handled.  
JS files are injected into `head` as default, but `useHead: false`, will make it inject into the Web Component instead.

## useExternalSource hook
This hook can be used to hook into the loading state of an external source.  
The hook is used like this:

```js
const App = (props) => {
  // hasLoaded become a state with value 'true' or 'false', depending on whether the resource has fully loaded or not.
  const hasLoaded = useExternalSource('https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css');

  return (
    ...
  );
}
```

**How did you verify that your changes work as expected? Please describe**  
Tested the functionality locally, and verified that it works.  
Made sure that all integration and unit tests are passing.

**Version**  
3.4.14