### PR TITLE
Address #151 Replace node-sass with sass package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.4.15",
+  "version": "3.4.16",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.4.15",
+  "version": "3.4.16",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",
@@ -19,8 +19,8 @@
   "dependencies": {
     "chalk": "2.4.2",
     "lodash.clonedeep": "4.5.0",
-    "node-sass": "4.13.0",
     "react-lib-adler32": "^1.0.3",
+    "sass": "^1.26.10",
     "webfontloader": "1.6.28"
   },
   "devDependencies": {

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.4.15",
+  "version": "3.4.16",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.15",
-    "direflow-scripts": "3.4.15"
+    "direflow-component": "3.4.16",
+    "direflow-scripts": "3.4.16"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.4.15",
-    "direflow-scripts": "3.4.15"
+    "direflow-component": "3.4.16",
+    "direflow-scripts": "3.4.16"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
`sass` is now the preferred NPM package for compiling Sass stylesheets.
It contains the most up to date features and is updated more regularly
by the Sass team.  Furthermore, It is recommended for use with the
`sass-loader` webpack plugin.  https://webpack.js.org/loaders/sass-loader/

**What does this pull request introduce? Please describe**  
Switches the NPM dependency from `node-sass` to `sass`

**How did you verify that your changes work as expected? Please describe**  
Tested in my consuming application by `npm link`ing the updated package.  Sass stylesheets
that use @use that did not previously compile now compile.

Did you remember to update the version of Direflow as explained here:  YES
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version