### PR TITLE
Fixes #200: Material-UI classes unique names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.5.0",
+  "version": "3.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package-lock.json
+++ b/packages/direflow-component/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.5.0-link",
+  "version": "3.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,6 +14,15 @@
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
       "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.uniqueid": {
+      "version": "4.0.6",
+      "resolved": "https://nexus.lbg.office.fr.lyra/repository/npm-all/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.6.tgz",
+      "integrity": "sha512-WXXsDm7Q1SiAeCG9ubCiDxOuLEDi5x+Crx8SgwTFgBtofATwK1jAeSbGz2bHlfqWezi7mcjynenlBFCeDLhHlw==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -186,6 +195,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://nexus.lbg.office.fr.lyra/repository/npm-all/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",
@@ -19,12 +19,14 @@
   "dependencies": {
     "chalk": "2.4.2",
     "lodash.clonedeep": "4.5.0",
+    "lodash.uniqueid": "^4.0.1",
     "react-lib-adler32": "^1.0.3",
     "sass": "^1.26.10",
     "webfontloader": "1.6.28"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "4.5.6",
+    "@types/lodash.uniqueid": "^4.0.6",
     "@types/react": "16.9.25",
     "@types/react-dom": "16.9.5",
     "@types/webfontloader": "1.6.29",

--- a/packages/direflow-component/src/plugins/materialUiPlugin.tsx
+++ b/packages/direflow-component/src/plugins/materialUiPlugin.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import uniqueid from 'lodash.uniqueid';
 import { IDireflowPlugin } from '../types/DireflowConfig';
 import { PluginRegistrator } from '../types/PluginRegistrator';
 
@@ -12,7 +13,8 @@ const materialUiPlugin: PluginRegistrator = (
   if (plugins?.find((plugin) => plugin.name === 'material-ui')) {
     try {
       const { create } = require('jss');
-      const { jssPreset, StylesProvider } = require('@material-ui/core/styles');
+      const { jssPreset, StylesProvider, createGenerateClassName } = require('@material-ui/core/styles');
+      const seed = uniqueid(`${element.tagName.toLowerCase()}-`);
       const insertionPoint = document.createElement('span');
       insertionPoint.id = 'direflow_material-ui-styles';
 
@@ -27,7 +29,16 @@ const materialUiPlugin: PluginRegistrator = (
         jssCache.set(element, jss);
       }
 
-      return [<StylesProvider jss={jss} sheetsManager={new Map()}>{app}</StylesProvider>, insertionPoint];
+      return [
+        <StylesProvider
+          jss={jss}
+          sheetsManager={new Map()}
+          generateClassName={createGenerateClassName({ seed })}
+        >
+          {app}
+        </StylesProvider>,
+        insertionPoint,
+      ];
     } catch (err) {
       console.error('Could not load Material-UI. Did you remember to install @material-ui/core?');
     }

--- a/packages/direflow-scripts/package-lock.json
+++ b/packages/direflow-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.5.0-link",
+  "version": "3.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.5.1",
-    "direflow-scripts": "3.5.1"
+    "direflow-component": "3.5.2",
+    "direflow-scripts": "3.5.2"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.5.1",
-    "direflow-scripts": "3.5.1"
+    "direflow-component": "3.5.2",
+    "direflow-scripts": "3.5.2"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
CSS classes created by Material-UI now have unique names to avoid style corruption between components (IE 11 bug, see #200).

**How did you verify that your changes work as expected? Please describe**  
I used my little [demo project](https://github.com/alex-fournier/hello-direflow.git) with direflow-component linked to confirm that it fixes the bug in IE 11.

**Example**  
Please describe how we can try out your changes  
1. Checkout this demo project: https://github.com/alex-fournier/hello-direflow.git
2. Link this version of direflow-component
3. Start demo project and check in IE 11 that the Select component from Material-UI is displayed correctly.

**Screenshots**  
Screenshot of IE 11, Select component is now working:
![fixed](https://user-images.githubusercontent.com/1874622/106004161-38020100-60b3-11eb-800e-ff72bc475365.jpg)

**Version**  
3.5.2