### PR TITLE
[Feature] - Added anonymous slot for webcomponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-component/src/DireflowComponent.tsx
+++ b/packages/direflow-component/src/DireflowComponent.tsx
@@ -44,6 +44,7 @@ class DireflowComponent {
 
     const tagName = configuration.tagname || 'direflow-component';
     const shadow = configuration.useShadow !== undefined ? configuration.useShadow : true;
+    const anonymousSlot = configuration.useAnonymousSlot !== undefined ? configuration.useAnonymousSlot : false;
 
     (async () => {
       /**
@@ -55,6 +56,7 @@ class DireflowComponent {
         componentProperties,
         component,
         shadow,
+        anonymousSlot,
         plugins,
         callback,
       ).create();

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -15,6 +15,7 @@ class WebComponentFactory {
     private componentProperties: { [key: string]: unknown },
     private rootComponent: React.FC<any> | React.ComponentClass<any, any>,
     private shadow?: boolean,
+    private anonymousSlot?: boolean,
     private plugins?: IDireflowPlugin[],
     private connectCallback?: (element: HTMLElement) => void,
   ) {
@@ -228,9 +229,10 @@ class WebComponentFactory {
        * Mount React App onto the Web Component
        */
       public mountReactApp(options?: { initial: boolean }) {
+        const anonymousSlot = factory.anonymousSlot ? React.createElement('slot') : undefined;
         const application = (
           <EventProvider value={this.eventDispatcher}>
-            {React.createElement(factory.rootComponent, this.reactProps())}
+            {React.createElement(factory.rootComponent, this.reactProps(), anonymousSlot)}
           </EventProvider>
         );
 

--- a/packages/direflow-component/src/types/DireflowConfig.ts
+++ b/packages/direflow-component/src/types/DireflowConfig.ts
@@ -8,6 +8,7 @@ export interface IDireflowComponent {
 export interface IDireflowConfig {
   tagname: string;
   useShadow?: boolean;
+  useAnonymousSlot?: boolean;
 }
 
 export interface IDireflowPlugin {

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-scripts/src/config/config-overrides.ts
+++ b/packages/direflow-scripts/src/config/config-overrides.ts
@@ -101,6 +101,11 @@ function overrideModule(module: IModule) {
     use: ['@svgr/webpack'],
   });
 
+  module.rules[2].oneOf.unshift({
+    test: /\.tsx$/,
+    use: ['ts-loader'],
+  });
+
   return module;
 }
 

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.5.3",
-    "direflow-scripts": "3.5.3"
+    "direflow-component": "3.5.4",
+    "direflow-scripts": "3.5.4"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.5.3",
-    "direflow-scripts": "3.5.3"
+    "direflow-component": "3.5.4",
+    "direflow-scripts": "3.5.4"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Introduces a list of child react nodes when mounting a react app so that things like text or nested tags within web components will populate.

e.g.: 
<webcomponent-react-button>
  <i>This text will now display</i>
</webcomponent-react-button>

**How did you verify that your changes work as expected? Please describe**  
Anonymous slot will not be used if useAnonymousSlot is configured to false in the config file.
It will be used if set to true.

**Example**  
Please describe how we can try out your changes  
1. Set 'useAnonymousSlot' to true in the Direflow config
2. Create a new react element which can have nested text/tags
3. Convert the react element into a webcomponent
4. Consume the new webcomponent and place a nested <i> tag within the component with some text.
5. Use dev tools to see that the <i> tag has been revealed in the 'slot' of the parent components' shadow-root


**Screenshots**  
If applicable, add screenshots to demonstrate your changes.

**Version**  
Which version is your changes included in?  
 3.5.4

Did you remember to update the version of Direflow as explained here:  
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version