### PR TITLE
Feature/fix after npm upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.5.3",
-    "direflow-scripts": "3.5.3"
+    "direflow-component": "3.5.4",
+    "direflow-scripts": "3.5.4"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "direflow-component": "3.5.3",
-    "direflow-scripts": "3.5.3"
+    "direflow-component": "3.5.4",
+    "direflow-scripts": "3.5.4"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Make `direflow-scripts start` and `direflow-scripts build` work again after npm dependencies upgrade.
Fixes #214 

I encountered 3 issues:
1. When a webpack build entry is passed as a single string, instead of wrapping the string to array, it was split to an array of characters.
2. Index of Nested Rules (`oneOf`) in Webpack module rules array changed. 
3. When env is development (`start` command), entry was not spliced out correctly.

The following fixes were applied:
1. Use `flat()` to make sure that value is an array.
2. Find index of rule which contains `oneOf` key.
3. For both Prod and Dev spice out always entry on index 0. 

Please verify especially 3rd fix as I am unsure what could influence entry array.

**How did you verify that your changes work as expected? Please describe**  
- I tested manually `start` and `build` in my local project. I didn't test `build:lib`.
- Jest tests were green.
- Cypress tests have 9 fails. But then I tried to run them on development and master and same failed tests are everywhere.
I run the test-setup from WSL and cypress was opened on Windows host machine. 

**Example**  
Previous versions:
```
    "direflow-component": "3.5.1",
    "direflow-scripts": "3.5.1",
    "react": "16.13.1",
    "react-app-polyfill": "^1.0.6",
    "react-beforeunload": "^2.2.4",
    "react-dom": "16.13.1",
    "react-hook-form": "^6.9.2",
    "react-i18next": "^11.7.3",
    "react-redux": "^7.2.2",
    "react-scripts": "^3.4.0",
```
After upgrade:
```    
    "direflow-component": "3.5.3",
    "direflow-scripts": "3.5.3",
    "react": "17.0.2",
    "react-app-polyfill": "^2.0.0",
    "react-beforeunload": "^2.4.0",
    "react-dom": "17.0.2",
    "react-hook-form": "^7.2.1",
    "react-i18next": "^11.8.13",
    "react-redux": "^7.2.3",
    "react-scripts": "^4.0.3",
```

**Screenshots**  
If applicable, add screenshots to demonstrate your changes.
Master:
![direflow-cypress-master](https://user-images.githubusercontent.com/875994/116402547-d9246300-a82c-11eb-8707-5a8a6f31dd66.png)

Development:
![direflow-cypress-development](https://user-images.githubusercontent.com/875994/116402584-e2adcb00-a82c-11eb-9163-6162d475c394.png)

Feature:
![direflow-cypress-feature](https://user-images.githubusercontent.com/875994/116402600-e6415200-a82c-11eb-8d34-ccc5abd6be31.png)


**Version**  
`3.5.3` bumped to `3.5.4`
  
Did you remember to update the version of Direflow as explained here:  
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version