### PR TITLE
Fixing the error

### DIFF
--- a/packages/direflow-scripts/direflow-jest.config.js
+++ b/packages/direflow-scripts/direflow-jest.config.js
@@ -1,7 +1,7 @@
 const { createContext } = require('react');
 
 // eslint-disable-next-line no-undef
-jest.mock('../direflow-component', () => ({
+jest.doMock('../direflow-component', () => ({
   Styled: (props) => {
     return props.children;
   },


### PR DESCRIPTION
error : Invalid variable access: createContext
    Whitelisted objects: Array, ArrayBuffer, Boolean, DataView, Date, Error, EvalError, Float32Array, Float64Array, Function, Generator, GeneratorFunction, Infinity, Int16Array, Int32Array, Int8Array, InternalError, Intl, JSON, Map, Math, NaN, Number, Object, Promise, Proxy, RangeError, ReferenceError, Reflect, RegExp, Set, String, Symbol, SyntaxError, TypeError, URIError, Uint16Array, Uint32Array, Uint8Array, Uint8ClampedArray, WeakMap, WeakSet, arguments, console, expect, isNaN, jest, parseFloat, parseInt, require, undefined, globalThis, BigUint64Array, BigInt64Array, BigInt, decodeURI, decodeURIComponent, encodeURI, encodeURIComponent, escape, unescape, eval, isFinite, SharedArrayBuffer, Atomics, FinalizationRegistry, WeakRef, WebAssembly, global, process, Buffer, URL, URLSearchParams, TextEncoder, TextDecoder, clearInterval, clearTimeout, setInterval, setTimeout, queueMicrotask, clearImmediate, setImmediate.
    Note: This is a precaution to guard against uninitialized mock variables. If it is ensured that the mock is required lazily, variable names prefixed with `mock` (case insensitive) are permitted.

**What does this pull request introduce? Please describe**  
It fixes the error above.

**How did you verify that your changes work as expected? Please describe**  
I tested it.

**Example**  
Please describe how we can try out your changes  
1. Run the test
2. See you won't get the above error anymore

**Version**  
Which version is your changes included in?  
Latest
  
Did you remember to update the version of Direflow as explained here:  
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version

No I didn't clone the repository just made this change online in github.