### PR TITLE
feat: add useNamedSlots to support named slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "direflow-cli",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "direflow-cli",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
         "boxen": "^4.1.0",

--- a/packages/direflow-component/package-lock.json
+++ b/packages/direflow-component/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "direflow-component",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.3",
+      "name": "direflow-component",
+      "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "2.4.2",
@@ -24,8 +25,8 @@
         "typescript": "3.9.3"
       },
       "peerDependencies": {
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1"
+        "react": "16.13.1",
+        "react-dom": "16.13.1"
       }
     },
     "node_modules/@types/lodash": {

--- a/packages/direflow-component/src/DireflowComponent.tsx
+++ b/packages/direflow-component/src/DireflowComponent.tsx
@@ -45,6 +45,7 @@ class DireflowComponent {
     const tagName = configuration.tagname || 'direflow-component';
     const shadow = configuration.useShadow !== undefined ? configuration.useShadow : true;
     const anonymousSlot = configuration.useAnonymousSlot !== undefined ? configuration.useAnonymousSlot : false;
+    const namedSlots = Array.isArray(configuration.useNamedSlots) ? configuration.useNamedSlots : false;
 
     (async () => {
       /**
@@ -57,6 +58,7 @@ class DireflowComponent {
         component,
         shadow,
         anonymousSlot,
+        namedSlots,
         plugins,
         callback,
       ).create();

--- a/packages/direflow-component/src/WebComponentFactory.tsx
+++ b/packages/direflow-component/src/WebComponentFactory.tsx
@@ -16,6 +16,7 @@ class WebComponentFactory {
     private rootComponent: React.FC<any> | React.ComponentClass<any, any>,
     private shadow?: boolean,
     private anonymousSlot?: boolean,
+    private namedSlots?: string[],
     private plugins?: IDireflowPlugin[],
     private connectCallback?: (element: HTMLElement) => void,
   ) {
@@ -230,9 +231,10 @@ class WebComponentFactory {
        */
       public mountReactApp(options?: { initial: boolean }) {
         const anonymousSlot = factory.anonymousSlot ? React.createElement('slot') : undefined;
+        const namedSlots = factory.namedSlots ? factory.namedSlots.map((name) => React.createElement('slot', { name })) : undefined;
         const application = (
           <EventProvider value={this.eventDispatcher}>
-            {React.createElement(factory.rootComponent, this.reactProps(), anonymousSlot)}
+            {React.createElement(factory.rootComponent, this.reactProps(), [anonymousSlot, namedSlots])}
           </EventProvider>
         );
 

--- a/packages/direflow-component/src/types/DireflowConfig.ts
+++ b/packages/direflow-component/src/types/DireflowConfig.ts
@@ -9,6 +9,7 @@ export interface IDireflowConfig {
   tagname: string;
   useShadow?: boolean;
   useAnonymousSlot?: boolean;
+  useNamedSlots?: string[];
 }
 
 export interface IDireflowPlugin {

--- a/packages/direflow-scripts/package-lock.json
+++ b/packages/direflow-scripts/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "direflow-scripts",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.3",
+      "name": "direflow-scripts",
+      "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
         "@svgr/webpack": "4.3.2",


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Add useNamedSlots to support named slots.

**How did you verify that your changes work as expected? Please describe**  
Add useNamedSlots option for DireflowComponent.create's configuration.

**Example**  
Please describe how we can try out your changes  
```js
import { DireflowComponent } from "direflow-component";

export default DireflowComponent.create({
  configuration: {
    tagname: "test-comp",
    useShadow: true,
    useNamedSlots: ['slot1', 'slot2']
  },
});
```
```html
<test-comp>
    <p slot="slot1">I'm slot1</p>

    <div slot="slot2">I'm slot2</div>
</test-comp>
```

**Screenshots**  
If applicable, add screenshots to demonstrate your changes.

![image](https://user-images.githubusercontent.com/19262750/161010938-a1e0fd29-856c-49be-a78f-0fc8ec22f9f8.png)


**Version**  
Which version is your changes included in?  
3.5.4
  
Did you remember to update the version of Direflow as explained here:  
https://github.com/Silind-Software/direflow/blob/master/CONTRIBUTING.md#version